### PR TITLE
manipcli: fix panic in setViperFlagsWithPrefix

### DIFF
--- a/manipcli/utils.go
+++ b/manipcli/utils.go
@@ -367,7 +367,12 @@ func setViperFlagsWithPrefix(cmd *cobra.Command, specifiable elemental.Attribute
 
 		case "ref":
 			fv := rv.FieldByName(spec.ConvertedName)
-			instance := reflect.New(fv.Type().Elem())
+			var instance reflect.Value
+			if fv.Kind() == reflect.Pointer {
+				instance = reflect.New(fv.Type().Elem())
+			} else {
+				instance = reflect.New(fv.Type())
+			}
 
 			specifiable, ok := instance.Interface().(elemental.AttributeSpecifiable)
 			if !ok {


### PR DESCRIPTION
In setViperFlagsWithPrefix() we sitch on the spec type and we assume that if the type is ref that the instance type must be a pointer to a struct. However, in the case of the type being just a struct, the reflect call to Elem() will panic as the kind is not a pointer.