### PR TITLE
manipcli: fix panic in readViperFlagsWithPrefix

### DIFF
--- a/filter.go
+++ b/filter.go
@@ -94,9 +94,10 @@ func NewPropagationFilterWithCustomProperty(
 	addititionalFiltering *elemental.Filter,
 ) *elemental.Filter {
 
-	filters := []*elemental.Filter{}
+	ancestors := elemental.NamespaceAncestorsNames(namespace)
+	filters := make([]*elemental.Filter, 0, len(ancestors))
 
-	for _, pns := range elemental.NamespaceAncestorsNames(namespace) {
+	for _, pns := range ancestors {
 		f := NewNamespaceFilterWithCustomProperty(namespacePropName, pns, false).
 			WithKey(propagationPropName).Equals(true).
 			Done()

--- a/manipcli/cli.go
+++ b/manipcli/cli.go
@@ -83,12 +83,13 @@ func ManipulatorMakerFromFlags(options ...maniphttp.Option) ManipulatorMaker {
 			RootCAs:            rootCAPool,
 		}
 
-		opts := []maniphttp.Option{
+		opts := make([]maniphttp.Option, 0, 4+len(options)+len(innerOptions))
+		opts = append(opts,
 			maniphttp.OptionNamespace(namespace),
 			maniphttp.OptionTLSConfig(tlsConfig),
 			maniphttp.OptionEncoding(enc),
 			maniphttp.OptionToken(token),
-		}
+		)
 
 		opts = append(opts, options...)
 		opts = append(opts, innerOptions...)

--- a/manipcli/utils.go
+++ b/manipcli/utils.go
@@ -251,7 +251,15 @@ func readViperFlagsWithPrefix(specifiable elemental.AttributeSpecifiable, prefix
 
 		case "ref":
 
-			instance := reflect.New(fv.Type().Elem())
+			isPtr := fv.Type().Kind() == reflect.Ptr
+			var elemType reflect.Type
+			if isPtr {
+				elemType = fv.Type().Elem()
+			} else {
+				elemType = fv.Type()
+			}
+
+			instance := reflect.New(elemType)
 			specifiable, ok := instance.Interface().(elemental.AttributeSpecifiable)
 
 			if !ok {
@@ -281,7 +289,11 @@ func readViperFlagsWithPrefix(specifiable elemental.AttributeSpecifiable, prefix
 			}
 
 			if innerDidSet {
-				fv.Set(reflect.ValueOf(specifiable))
+				if isPtr {
+					fv.Set(reflect.ValueOf(specifiable))
+				} else {
+					fv.Set(reflect.ValueOf(specifiable).Elem())
+				}
 				didSet = true
 			}
 


### PR DESCRIPTION
In readViperFlagsWithPrefix() we switch on the spec type and we assume that if the type is ref that the field type must be a pointer to a struct. However, in the case of the type being just a struct, the reflect call to Elem() will panic as the kind is not a pointer.