### PR TITLE
new: implement DeleteMany for collection-level DELETE under parent

### DIFF
--- a/manipcli/delete_many.go
+++ b/manipcli/delete_many.go
@@ -12,6 +12,26 @@ import (
 )
 
 // generateDeleteManyCommandForIdentity generates the command to delete many objects based on its identity.
+//
+// Two mutually exclusive run modes:
+//
+//   - --parent: calls manipulator.DeleteMany directly. A single HTTP DELETE
+//     on the parent-scoped collection URL, with query parameters from -p
+//     riding along via mctx.Parameters(). This is the route for
+//     narrowly-targeted collection-level deletes where the server identifies
+//     the target via required query params (e.g. revoking a named token on a
+//     parent resource).
+//
+//   - --filter (or neither flag): fetch-then-individual-delete loop. The
+//     command RetrieveMany's matching objects then iterates and Delete's
+//     each one. Requires --confirm. This is the historical behavior for
+//     bulk-by-predicate deletes where per-object error reporting matters.
+//
+// Combining --parent with --filter is rejected: the two flags express
+// distinct identification strategies (server-side query param vs.
+// client-side predicate) and supporting their combination would mean
+// fetch-loop semantics under a parent collection — a fourth shape that
+// nothing currently asks for.
 func generateDeleteManyCommandForIdentity(identity elemental.Identity, modelManager elemental.ModelManager, manipulatorMaker ManipulatorMaker) *cobra.Command {
 
 	cmd := &cobra.Command{
@@ -30,6 +50,10 @@ func generateDeleteManyCommandForIdentity(identity elemental.Identity, modelMana
 			fOutputTemplate := viper.GetString(flagOutputTemplate)
 			fNamespace := viper.GetString(flagNamespace)
 
+			if viper.IsSet(flagParent) && fFilter != "" {
+				return fmt.Errorf("--%s and --%s cannot be used together: --%s does a single collection-level DELETE (server identifies targets via -p query params), while --%s does a fetch-then-delete loop. Pick one", flagParent, flagFilter, flagParent, flagFilter)
+			}
+
 			manipulator, err := manipulatorMaker()
 			if err != nil {
 				return fmt.Errorf("unable to make manipulator: %w", err)
@@ -47,6 +71,19 @@ func generateDeleteManyCommandForIdentity(identity elemental.Identity, modelMana
 				manipulate.ContextOptionOverride(fConfirm),
 			}
 
+			if viper.IsSet(flagParent) {
+				parentName, parentID, err := splitParentInfo(viper.GetString(flagParent))
+				if err != nil {
+					return err
+				}
+				parent := modelManager.IdentifiableFromString(parentName)
+				if parent == nil {
+					return fmt.Errorf("unknown identity %s", parentName)
+				}
+				parent.SetIdentifier(parentID)
+				options = append(options, manipulate.ContextOptionParent(parent))
+			}
+
 			if fFilter != "" {
 				f, err := elemental.NewFilterFromString(fFilter)
 				if err != nil {
@@ -60,6 +97,35 @@ func generateDeleteManyCommandForIdentity(identity elemental.Identity, modelMana
 
 			mctx := manipulate.NewContext(ctx, options...)
 
+			// --parent → single collection-level DELETE via manipulator.DeleteMany.
+			// The server identifies the target(s) via query params (`-p key=value`)
+			// declared by the spec relation. The --parent + --filter combination
+			// was rejected earlier, so reaching here without a filter is the only
+			// possibility.
+			if viper.IsSet(flagParent) {
+				if err := manipulator.DeleteMany(mctx, identity); err != nil {
+					return fmt.Errorf("unable to delete %s: %w", identity.Category, err)
+				}
+
+				outputType := fOutput
+				if fOutput == flagOutputDefault {
+					outputType = flagOutputNone
+				}
+
+				result, err := formatObjects(
+					prepareOutputFormat(outputType, formatTypeArray, fFormatTypeColumn, fOutputTemplate),
+					true,
+				)
+
+				if err != nil {
+					return fmt.Errorf("unable to format output: %w", err)
+				}
+
+				_, _ = fmt.Fprint(cmd.OutOrStdout(), result)
+				return nil
+			}
+
+			// --filter set → legacy fetch-then-individual-delete loop.
 			identifiables := modelManager.Identifiables(identity)
 			if err := manipulator.RetrieveMany(mctx, identifiables); err != nil {
 				return fmt.Errorf("unable to retrieve %s: %w", identity.Category, err)
@@ -117,6 +183,7 @@ func generateDeleteManyCommandForIdentity(identity elemental.Identity, modelMana
 
 	cmd.Flags().StringP(flagFilter, "f", "", "Query filter.")
 	cmd.Flags().BoolP(flagConfirm, "", false, "Confirm deletion of multiple objects")
+	cmd.Flags().StringP(flagParent, "", "", "Provide information about parent resource. Format `name/ID`")
 
 	return cmd
 }

--- a/maniphttp/manipulator.go
+++ b/maniphttp/manipulator.go
@@ -411,7 +411,32 @@ func (s *httpManipulator) Delete(mctx manipulate.Context, object elemental.Ident
 }
 
 func (s *httpManipulator) DeleteMany(mctx manipulate.Context, identity elemental.Identity) error {
-	return manipulate.ErrNotImplemented{Err: fmt.Errorf("DeleteMany not implemented in maniphttp")}
+
+	if mctx == nil {
+		ctx, cancel := context.WithTimeout(context.Background(), defaultGlobalContextTimeout)
+		defer cancel()
+		mctx = manipulate.NewContext(ctx)
+	}
+
+	sp := tracing.StartTrace(mctx, fmt.Sprintf("maniphttp.delete_many.%s", identity.Category))
+	defer sp.Finish()
+
+	url, err := s.getURLForChildrenIdentity(mctx.Parent(), identity, 0, mctx.Version())
+	if err != nil {
+		sp.SetTag("error", true)
+		sp.LogFields(log.Error(err))
+		return manipulate.ErrCannotBuildQuery{Err: err}
+	}
+
+	response, err := s.send(mctx, http.MethodDelete, url, nil, nil, sp)
+	if err != nil {
+		sp.SetTag("error", true)
+		sp.LogFields(log.Error(err))
+		return err
+	}
+	defer func() { _ = response.Body.Close() }()
+
+	return nil
 }
 
 func (s *httpManipulator) Count(mctx manipulate.Context, identity elemental.Identity) (int, error) {

--- a/maniphttp/manipulator_test.go
+++ b/maniphttp/manipulator_test.go
@@ -19,6 +19,7 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -924,15 +925,114 @@ func TestHTTP_Delete(t *testing.T) {
 
 func TestHTTP_DeleteMany(t *testing.T) {
 
-	Convey("Given I have a manipulator", t, func() {
+	Convey("Given I have a manipulator and a working server that captures the request", t, func() {
 
-		mm, _ := New(context.Background(), "https://fake.com")
+		var gotMethod, gotPath, gotRawQuery string
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			gotMethod = r.Method
+			gotPath = r.URL.Path
+			gotRawQuery = r.URL.RawQuery
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusNoContent)
+		}))
+		defer ts.Close()
+
+		mm, _ := New(context.Background(), ts.URL)
 		m := mm.(*httpManipulator)
 
-		err := m.DeleteMany(nil, testmodel.TaskIdentity)
+		Convey("When I DeleteMany without parent", func() {
 
-		Convey("Then err should not be nil", func() {
-			So(err, ShouldNotBeNil)
+			err := m.DeleteMany(nil, testmodel.TaskIdentity)
+
+			Convey("Then it sends DELETE to the bare collection URL", func() {
+				So(err, ShouldBeNil)
+				So(gotMethod, ShouldEqual, http.MethodDelete)
+				So(gotPath, ShouldEqual, "/tasks")
+				So(gotRawQuery, ShouldEqual, "")
+			})
+		})
+
+		Convey("When I DeleteMany under a parent", func() {
+
+			list := testmodel.NewList()
+			list.ID = "xxx"
+
+			ctx := manipulate.NewContext(
+				context.Background(),
+				manipulate.ContextOptionParent(list),
+			)
+
+			err := m.DeleteMany(ctx, testmodel.TaskIdentity)
+
+			Convey("Then it sends DELETE to the parent-scoped collection URL", func() {
+				So(err, ShouldBeNil)
+				So(gotMethod, ShouldEqual, http.MethodDelete)
+				// Parent (List) has Version() == 1, so the path picks up the
+				// /v/1/ prefix via computeVersion(parent.Version(), ...).
+				So(gotPath, ShouldEqual, "/v/1/lists/xxx/tasks")
+			})
+		})
+
+		Convey("When I DeleteMany with query parameters", func() {
+
+			list := testmodel.NewList()
+			list.ID = "xxx"
+
+			params := url.Values{}
+			params.Set("name", "todo-1")
+
+			ctx := manipulate.NewContext(
+				context.Background(),
+				manipulate.ContextOptionParent(list),
+				manipulate.ContextOptionParameters(params),
+			)
+
+			err := m.DeleteMany(ctx, testmodel.TaskIdentity)
+
+			Convey("Then query params from the context ride along on the URL", func() {
+				So(err, ShouldBeNil)
+				So(gotMethod, ShouldEqual, http.MethodDelete)
+				So(gotPath, ShouldEqual, "/v/1/lists/xxx/tasks")
+				So(gotRawQuery, ShouldContainSubstring, "name=todo-1")
+			})
+		})
+
+		Convey("When I DeleteMany under a parent that has no ID", func() {
+
+			list := testmodel.NewList()
+
+			ctx := manipulate.NewContext(
+				context.Background(),
+				manipulate.ContextOptionParent(list),
+			)
+
+			err := m.DeleteMany(ctx, testmodel.TaskIdentity)
+
+			Convey("Then err should be an ErrCannotBuildQuery", func() {
+				So(err, ShouldNotBeNil)
+				So(err, ShouldHaveSameTypeAs, manipulate.ErrCannotBuildQuery{})
+			})
+		})
+	})
+
+	Convey("Given I have a manipulator and a server that returns an error", t, func() {
+
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusInternalServerError)
+		}))
+		defer ts.Close()
+
+		mm, _ := New(context.Background(), ts.URL)
+		m := mm.(*httpManipulator)
+
+		Convey("When I DeleteMany", func() {
+
+			err := m.DeleteMany(nil, testmodel.TaskIdentity)
+
+			Convey("Then the server error propagates", func() {
+				So(err, ShouldNotBeNil)
+			})
 		})
 	})
 }


### PR DESCRIPTION
maniphttp.DeleteMany previously returned ErrNotImplemented, leaving no client-side path to hit a registered `DELETE /parents/<pid>/children` route. Implement it modeled on Count: build the URL via getURLForChildrenIdentity (respects mctx.Parent()), send DELETE, let query params from mctx.Parameters() ride along via the existing send() plumbing.

manipcli: extend `delete-many` with a `--parent` flag that routes to the new DeleteMany verb (single HTTP call, server identifies targets via -p query params). The existing --filter path is preserved as the fetch-then-individual-delete loop. The two flags are mutually exclusive — combining them is rejected upfront, since they express distinct identification strategies and fetch-loop-under-parent is a shape nothing currently asks for.

Tests cover the URL/method/query-param wiring for DeleteMany with and without parent, plus the no-ID parent error path.