### PR TITLE
manipcli: support --template to specify a golang template to parse th…

### DIFF
--- a/manipcli/list.go
+++ b/manipcli/list.go
@@ -120,6 +120,7 @@ func generateListCommandForIdentity(identity elemental.Identity, modelManager el
 	cmd.Flags().StringP(flagNext, "N", "", "Pages after next ID.")
 	cmd.Flags().IntP(flagLimit, "L", 0, "Pages number to retrieve after Next ID.")
 	cmd.Flags().StringP(flagFilter, "f", "", "Query filter.")
+	cmd.Flags().StringP(flagOutputTemplate, "", "", "Template the output using a Golang template.")
 	cmd.Flags().StringSliceP(flagOrder, "O", nil, "Ordering of the result.")
 	cmd.Flags().StringP(flagParent, "", "", "Provide information about parent resource. Format `name/ID`")
 


### PR DESCRIPTION
…e output

Somehow, we were missing this option which is very helpful to manage the output.
I just used it for a customer call. Here is an example:

```
acuctl api list agents -n /your-namespace -o template --template "{{range .}}{{.ID}},{{.principal.user.name}},{{.hostname}},{{.status}},{{.currentVersion}}\n{{end}}"
```