### PR TITLE
manipmongo: implement ContextOptionParent

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module go.acuvity.ai/manipulate
 go 1.26.1
 
 require (
-	go.acuvity.ai/elemental v0.0.0-20260708172111-828e3f761b65
+	go.acuvity.ai/elemental v0.0.0-20260714043849-103fa34baaeb
 	go.acuvity.ai/regolithe v0.0.0-20260601174230-81cdfce253df // indirect
 	go.acuvity.ai/wsc v1.0.0
 )

--- a/go.sum
+++ b/go.sum
@@ -207,8 +207,8 @@ github.com/youmark/pkcs8 v0.0.0-20240726163527-a2c0da244d78 h1:ilQV1hzziu+LLM3zU
 github.com/youmark/pkcs8 v0.0.0-20240726163527-a2c0da244d78/go.mod h1:aL8wCCfTfSfmXjznFBSZNN13rSJjlIOI1fUNAtF7rmI=
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
-go.acuvity.ai/elemental v0.0.0-20260708172111-828e3f761b65 h1:+SFukitxAGXm5877ukLpsGt6COxw5ughXvOV3jR0u8A=
-go.acuvity.ai/elemental v0.0.0-20260708172111-828e3f761b65/go.mod h1:O8cPy9ELFRHFmP0Uoj17NILwEX0M4aORbtyAHhU2N64=
+go.acuvity.ai/elemental v0.0.0-20260714043849-103fa34baaeb h1:dLIKdxEsH1ZioMfIR+0Xuc/GnOioEpHaf4ZE43dIKkY=
+go.acuvity.ai/elemental v0.0.0-20260714043849-103fa34baaeb/go.mod h1:O8cPy9ELFRHFmP0Uoj17NILwEX0M4aORbtyAHhU2N64=
 go.acuvity.ai/regolithe v0.0.0-20260601174230-81cdfce253df h1:P5k46yEISCVy6kpprsqXoaQOIE3vd+vMu5zZL3w5wz4=
 go.acuvity.ai/regolithe v0.0.0-20260601174230-81cdfce253df/go.mod h1:KuX0NAZzZX76xCIhsDcnKk73XDQBrNrJMXorokwCMto=
 go.acuvity.ai/tg v1.0.1-0.20260708162706-306a91e4d7dd h1:mNHaN6Es8aWBrGIuhJ6b97wHNCq0GqrHMlPQiqk7sa8=

--- a/manipmongo/manipulator.go
+++ b/manipmongo/manipulator.go
@@ -175,12 +175,18 @@ func (m *mongoManipulator) RetrieveMany(mctx manipulate.Context, dest elemental.
 		return spanErr(sp, err)
 	}
 
+	fParent, err := makeParentFilter(mctx)
+	if err != nil {
+		return spanErr(sp, err)
+	}
+
 	pipeline, err := makePipeline(
 		attrSpec,
 		makePreviousRetriever(mctx.Context(), coll, m.operationTimeout),
 		fSharding,
 		makeNamespaceFilter(mctx),
 		m.forcedReadFilter,
+		fParent,
 		makeUserFilter(mctx, attrSpec),
 		order,
 		mctx.After(),
@@ -374,6 +380,17 @@ func (m *mongoManipulator) Create(mctx manipulate.Context, object elemental.Iden
 	oid := bson.NewObjectID()
 	object.SetIdentifier(oid.Hex())
 
+	if parent := mctx.Parent(); parent != nil {
+		if parent.Identifier() == "" {
+			return spanErr(sp, manipulate.ErrCannotBuildQuery{Err: fmt.Errorf("parent '%s' has no identifier set", parent.Identity().Name)})
+		}
+		p, ok := object.(elemental.Parentable)
+		if !ok {
+			return spanErr(sp, manipulate.ErrCannotBuildQuery{Err: fmt.Errorf("object '%s' does not support a parent", object.Identity().Name)})
+		}
+		p.SetParentID(parent.Identifier())
+	}
+
 	if f := mctx.Finalizer(); f != nil {
 		if err := f(object); err != nil {
 			return spanErr(sp, err)
@@ -455,6 +472,13 @@ func (m *mongoManipulator) Create(mctx manipulate.Context, object elemental.Iden
 		}
 		if m.forcedReadFilter != nil {
 			ands = append(ands, m.forcedReadFilter)
+		}
+		fParent, err := makeParentFilter(mctx)
+		if err != nil {
+			return spanErr(sp, err)
+		}
+		if len(fParent) > 0 {
+			ands = append(ands, fParent)
 		}
 		filter = composeAndFilter(filter, ands...)
 
@@ -735,6 +759,13 @@ func (m *mongoManipulator) DeleteMany(mctx manipulate.Context, identity elementa
 	if m.forcedReadFilter != nil {
 		ands = append(ands, m.forcedReadFilter)
 	}
+	fParent, err := makeParentFilter(mctx)
+	if err != nil {
+		return spanErr(sp, err)
+	}
+	if len(fParent) > 0 {
+		ands = append(ands, fParent)
+	}
 	filter = composeAndFilter(filter, ands...)
 	sp.LogFields(log.Object("filter", filter))
 
@@ -787,12 +818,18 @@ func (m *mongoManipulator) Count(mctx manipulate.Context, identity elemental.Ide
 		return 0, spanErr(sp, err)
 	}
 
+	fParent, err := makeParentFilter(mctx)
+	if err != nil {
+		return 0, spanErr(sp, err)
+	}
+
 	pipeline, err := makePipeline(
 		attrSpec,
 		makePreviousRetriever(mctx.Context(), coll, m.operationTimeout),
 		fSharding,
 		makeNamespaceFilter(mctx),
 		m.forcedReadFilter,
+		fParent,
 		makeUserFilter(mctx, attrSpec),
 		nil,
 		mctx.After(),

--- a/manipmongo/manipulator_integration_test.go
+++ b/manipmongo/manipulator_integration_test.go
@@ -52,6 +52,8 @@ func (o *mongoIntegrationObject) Identity() elemental.Identity      { return mon
 func (o *mongoIntegrationObject) String() string                    { return o.Name }
 func (o *mongoIntegrationObject) Version() int                      { return 0 }
 func (o *mongoIntegrationObject) ValueForAttribute(name string) any { return nil }
+func (o *mongoIntegrationObject) GetParentID() string               { return o.ParentID }
+func (o *mongoIntegrationObject) SetParentID(id string)             { o.ParentID = id }
 
 type mongoIntegrationObjects []*mongoIntegrationObject
 
@@ -321,6 +323,104 @@ func TestOfficialManipulatorCRUDAndHelpersWithMemongo(t *testing.T) {
 
 	if err := SetConsistencyMode(manipulator, manipulate.ReadConsistencyNearest, manipulate.WriteConsistencyStrong); err != nil {
 		t.Fatalf("set mongo consistency mode failed: %v", err)
+	}
+}
+
+func TestOfficialManipulatorParentScopingWithMemongo(t *testing.T) {
+	uri, db := requireMemongo(t)
+
+	manipulator, err := New(uri, db, OptionForceReadFilter(mongobson.D{}))
+	if err != nil {
+		t.Fatalf("unable to create official manipulator: %v", err)
+	}
+
+	parentA := &mongoIntegrationObject{}
+	parentA.SetIdentifier(mongobson.NewObjectID().Hex())
+	parentB := &mongoIntegrationObject{}
+	parentB.SetIdentifier(mongobson.NewObjectID().Hex())
+
+	ctxParentA := manipulate.NewContext(context.Background(), manipulate.ContextOptionParent(parentA))
+	ctxParentB := manipulate.NewContext(context.Background(), manipulate.ContextOptionParent(parentB))
+
+	// Creating with a parent must stamp parentid onto the stored object.
+	for _, name := range []string{"child-a1", "child-a2"} {
+		child := newMongoIntegrationObject(name)
+		if err := manipulator.Create(ctxParentA, child); err != nil {
+			t.Fatalf("create child '%s' under parentA failed: %v", name, err)
+		}
+		if child.ParentID != parentA.Identifier() {
+			t.Fatalf("expected child '%s' parentid '%s', got '%s'", name, parentA.Identifier(), child.ParentID)
+		}
+	}
+	childB := newMongoIntegrationObject("child-b1")
+	if err := manipulator.Create(ctxParentB, childB); err != nil {
+		t.Fatalf("create child under parentB failed: %v", err)
+	}
+
+	// RetrieveMany scoped to parentA must only see parentA's children.
+	var listA mongoIntegrationObjects
+	if err := manipulator.RetrieveMany(ctxParentA, &listA); err != nil {
+		t.Fatalf("retrievemany under parentA failed: %v", err)
+	}
+	if len(listA) != 2 {
+		t.Fatalf("expected 2 children under parentA, got %d", len(listA))
+	}
+	for _, o := range listA {
+		if o.ParentID != parentA.Identifier() {
+			t.Fatalf("retrievemany under parentA returned foreign child with parentid '%s'", o.ParentID)
+		}
+	}
+
+	// Count scoped to parentA must be 2; unscoped count must be 3.
+	countA, err := manipulator.Count(ctxParentA, mongoIntegrationIdentity)
+	if err != nil {
+		t.Fatalf("count under parentA failed: %v", err)
+	}
+	if countA != 2 {
+		t.Fatalf("expected count 2 under parentA, got %d", countA)
+	}
+	countAll, err := manipulator.Count(manipulate.NewContext(context.Background()), mongoIntegrationIdentity)
+	if err != nil {
+		t.Fatalf("count all failed: %v", err)
+	}
+	if countAll != 3 {
+		t.Fatalf("expected 3 objects total, got %d", countAll)
+	}
+
+	// DeleteMany scoped to parentA must only delete parentA's children.
+	if err := manipulator.DeleteMany(ctxParentA, mongoIntegrationIdentity); err != nil {
+		t.Fatalf("deletemany under parentA failed: %v", err)
+	}
+	countAfter, err := manipulator.Count(manipulate.NewContext(context.Background()), mongoIntegrationIdentity)
+	if err != nil {
+		t.Fatalf("count after deletemany failed: %v", err)
+	}
+	if countAfter != 1 {
+		t.Fatalf("expected 1 object remaining after scoped deletemany, got %d", countAfter)
+	}
+	var listB mongoIntegrationObjects
+	if err := manipulator.RetrieveMany(ctxParentB, &listB); err != nil {
+		t.Fatalf("retrievemany under parentB failed: %v", err)
+	}
+	if len(listB) != 1 || listB[0].ParentID != parentB.Identifier() {
+		t.Fatalf("expected parentB's child to survive scoped deletemany, got %#v", listB)
+	}
+
+	// Create with a parent that has no identifier must error.
+	orphanParent := &mongoIntegrationObject{}
+	if err := manipulator.Create(
+		manipulate.NewContext(context.Background(), manipulate.ContextOptionParent(orphanParent)),
+		newMongoIntegrationObject("should-fail"),
+	); err == nil {
+		t.Fatalf("expected error creating with a parent without identifier")
+	}
+
+	// Create with a parent but a non-parentable object must error.
+	if err := manipulator.Create(
+		ctxParentA,
+		&mongoLegacyCompatObject{Name: "not-parentable"},
+	); err == nil {
+		t.Fatalf("expected error creating a non-parentable object with a parent")
 	}
 }
 

--- a/manipmongo/memongo_testutil_test.go
+++ b/manipmongo/memongo_testutil_test.go
@@ -31,8 +31,7 @@ const mongoTestDockerImageEnv = "MONGO_TEST_DOCKER_IMAGE"
 const mongoTestDockerStartupTimeoutEnv = "MONGO_TEST_DOCKER_STARTUP_TIMEOUT"
 const mongoTestDockerDisableEnv = "MONGO_TEST_DOCKER_DISABLE"
 
-// Default to a stable server image for integration tests.
-const defaultMongoTestDockerImage = "mongo:4.4.26"
+const defaultMongoTestDockerImage = "mongo:8"
 const defaultMongoTestDockerStartupTimeout = 60 * time.Second
 
 var dockerCommand = func(args ...string) ([]byte, error) {

--- a/manipmongo/utils.go
+++ b/manipmongo/utils.go
@@ -620,12 +620,30 @@ func makeUserFilter(mctx manipulate.Context, attrSpec elemental.AttributeSpecifi
 	return CompileFilter(f, opts...)
 }
 
+// makeParentFilter builds a filter constraining results to the children of the
+// parent set on the context via manipulate.ContextOptionParent. It returns a nil
+// filter when no parent is set.
+func makeParentFilter(mctx manipulate.Context) (bson.D, error) {
+
+	parent := mctx.Parent()
+	if parent == nil {
+		return nil, nil
+	}
+
+	if parent.Identifier() == "" {
+		return nil, manipulate.ErrCannotBuildQuery{Err: fmt.Errorf("parent '%s' has no identifier set", parent.Identity().Name)}
+	}
+
+	return bson.D{{Key: "parentid", Value: parent.Identifier()}}, nil
+}
+
 func makePipeline(
 	attrSpec elemental.AttributeSpecifiable,
 	retriever func(id bson.ObjectID) (bson.M, error),
 	shardFilter bson.D,
 	namespaceFilter bson.D,
 	forcedReadFilter bson.D,
+	parentFilter bson.D,
 	userFilter bson.D,
 	order []string,
 	after string,
@@ -648,6 +666,11 @@ func makePipeline(
 	// Add forced match.
 	if len(forcedReadFilter) > 0 {
 		pipe = append(pipe, bson.D{{Key: "$match", Value: forcedReadFilter}})
+	}
+
+	// Add parent match.
+	if len(parentFilter) > 0 {
+		pipe = append(pipe, bson.D{{Key: "$match", Value: parentFilter}})
 	}
 
 	// Ordering.

--- a/manipmongo/utils_test.go
+++ b/manipmongo/utils_test.go
@@ -73,6 +73,7 @@ func TestMakePipeline(t *testing.T) {
 		mongobson.D{{Key: "tenant", Value: "acuvity"}},
 		mongobson.D{{Key: "namespace", Value: "/ns"}},
 		mongobson.D{{Key: "active", Value: true}},
+		mongobson.D{{Key: "parentid", Value: "6a1dbccfbb0c837c0bf039d5"}},
 		mongobson.D{{Key: "status", Value: "ready"}},
 		[]string{"name"},
 		afterID.Hex(),
@@ -82,8 +83,8 @@ func TestMakePipeline(t *testing.T) {
 	if err != nil {
 		t.Fatalf("makePipeline returned unexpected error: %v", err)
 	}
-	if len(pipe) != 8 {
-		t.Fatalf("unexpected pipeline length: got %d want 8", len(pipe))
+	if len(pipe) != 9 {
+		t.Fatalf("unexpected pipeline length: got %d want 9", len(pipe))
 	}
 	if pipe[0][0].Key != "$match" {
 		t.Fatalf("unexpected first stage: %#v", pipe[0])
@@ -91,7 +92,7 @@ func TestMakePipeline(t *testing.T) {
 }
 
 func TestMakePipelineInvalidAfter(t *testing.T) {
-	_, err := makePipeline(nil, func(mongobson.ObjectID) (mongobson.M, error) { return nil, nil }, nil, nil, nil, nil, nil, "bad-after", 0, nil)
+	_, err := makePipeline(nil, func(mongobson.ObjectID) (mongobson.M, error) { return nil, nil }, nil, nil, nil, nil, nil, nil, "bad-after", 0, nil)
 	if err == nil {
 		t.Fatalf("expected invalid after error")
 	}
@@ -383,5 +384,61 @@ func assertErrorKind(t *testing.T, err error, want errorKind) {
 		}
 	default:
 		t.Fatalf("unsupported error kind %q", want)
+	}
+}
+
+func TestMakeParentFilter(t *testing.T) {
+
+	const parentID = "6a1dbccfbb0c837c0bf039d5"
+
+	parentWithID := &mongoIntegrationObject{}
+	parentWithID.SetIdentifier(parentID)
+
+	parentWithoutID := &mongoIntegrationObject{}
+
+	tests := []struct {
+		name       string
+		mctx       manipulate.Context
+		wantFilter mongobson.D
+		wantErr    bool
+	}{
+		{
+			name:       "no parent set",
+			mctx:       manipulate.NewContext(context.Background()),
+			wantFilter: nil,
+			wantErr:    false,
+		},
+		{
+			name:       "parent with identifier",
+			mctx:       manipulate.NewContext(context.Background(), manipulate.ContextOptionParent(parentWithID)),
+			wantFilter: mongobson.D{{Key: "parentid", Value: parentID}},
+			wantErr:    false,
+		},
+		{
+			name:    "parent without identifier",
+			mctx:    manipulate.NewContext(context.Background(), manipulate.ContextOptionParent(parentWithoutID)),
+			wantErr: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := makeParentFilter(test.mctx)
+			if test.wantErr {
+				if err == nil {
+					t.Fatalf("expected an error, got none")
+				}
+				if !errors.As(err, &manipulate.ErrCannotBuildQuery{}) {
+					t.Fatalf("expected ErrCannotBuildQuery, got %T: %v", err, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !reflect.DeepEqual(got, test.wantFilter) {
+				t.Fatalf("filter mismatch:\n got: %#v\nwant: %#v", got, test.wantFilter)
+			}
+		})
 	}
 }


### PR DESCRIPTION
Adds support for manipulate.ContextOptionParent in manipmongo. Previously, a mongo manipulator would silently swallow this option.

It adds support for this option in the following operations:
- RetrieveMany
- Create
- DeleteMany
- Count

This option is not necessary to implement for Retrieve and Delete.