### PR TITLE
manipcli: fix nameToFlag mangling of pluralized acronyms

### DIFF
--- a/manipcli/utils.go
+++ b/manipcli/utils.go
@@ -406,15 +406,29 @@ func setViperFlagsWithPrefix(cmd *cobra.Command, specifiable elemental.Attribute
 	return nil
 }
 
+var matchAcronymPluralMid = regexp.MustCompile("([A-Z]{2,})s([A-Z0-9])")
+var matchAcronymPluralEnd = regexp.MustCompile("([A-Z]{2,})s$")
 var matchFirstCap = regexp.MustCompile("(.)([A-Z][a-z]+)")
 var matchAllNumber = regexp.MustCompile("([a-z])([0-9]+)")
 var matchAllCap = regexp.MustCompile("([a-z])([A-Z])")
+var matchMultiDash = regexp.MustCompile("-+")
 
 func nameToFlag(name string) string {
-	flag := matchFirstCap.ReplaceAllString(name, "${1}-${2}")
+	// normalize pluralized acronyms into a single lowercased word fenced by dashes
+	flag := matchAcronymPluralMid.ReplaceAllStringFunc(name, func(m string) string {
+		g := matchAcronymPluralMid.FindStringSubmatch(m)
+		return "-" + strings.ToLower(g[1]+"s") + "-" + g[2]
+	})
+	flag = matchAcronymPluralEnd.ReplaceAllStringFunc(flag, func(m string) string {
+		g := matchAcronymPluralEnd.FindStringSubmatch(m)
+		return "-" + strings.ToLower(g[1]+"s")
+	})
+	flag = matchFirstCap.ReplaceAllString(flag, "${1}-${2}")
 	flag = matchAllNumber.ReplaceAllString(flag, "${1}-${2}")
 	flag = matchAllCap.ReplaceAllString(flag, "${1}-${2}")
-	return strings.ToLower(flag)
+	flag = strings.ToLower(flag)
+	flag = matchMultiDash.ReplaceAllString(flag, "-")
+	return strings.Trim(flag, "-")
 }
 
 type commonValues struct {

--- a/manipcli/utils_test.go
+++ b/manipcli/utils_test.go
@@ -565,6 +565,55 @@ func Test_nameToFlag(t *testing.T) {
 			},
 			"b2b-and-co",
 		},
+		{
+			"pluralized acronym at end",
+			args{
+				name: "publicURLs",
+			},
+			"public-urls",
+		},
+		{
+			"pluralized acronym only",
+			args{
+				name: "URLs",
+			},
+			"urls",
+		},
+		{
+			"pluralized two-letter acronym (minimum length treated as plural)",
+			args{
+				name: "subjectKeyIDs",
+			},
+			"subject-key-ids",
+		},
+		{
+			"pluralized acronym in the middle",
+			args{
+				name: "reportVisitedURLsInterval",
+			},
+			"report-visited-urls-interval",
+		},
+		{
+			"acronym followed by a word is not a plural",
+			args{
+				name: "IDPIssuer",
+			},
+			"idp-issuer",
+		},
+		{
+			"acronym with a number is preserved",
+			args{
+				name: "principalUserX509Field",
+			},
+			"principal-user-x509-field",
+		},
+		{
+			"single capital before s is not a plural acronym",
+			args{
+				name: "thingIsGood",
+			},
+			"thing-is-good",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
nameToFlag split a trailing lowercase plural 's' off an acronym, so attribute names like publicURLs produced --with.public-ur-ls instead of --with.public-urls. Also works for two consecutive pluralized acronyms now.

Effects all the following attributes from our specs:

| attribute | OLD flag (buggy) | NEW flag | source spec(s) |
|---|---|---|---|
| `URLs` | `--with.ur-ls` | `--with.urls` | `+mcpgatewayserver.spec` |
| `publicURLs` | `--with.public-ur-ls` | `--with.public-urls` | `deployment.spec` |
| `redirectURIs` | `--with.redirect-ur-is` | `--with.redirect-uris` | `aigatewayclient.spec`, `mcpgatewayclient.spec`, `oauthclient.spec` |
| `CNAMEs` | `--with.cnam-es` | `--with.cnames` | `+dnsreport.spec` |
| `subjectKeyIDs` | `--with.subject-key-i-ds` | `--with.subject-key-ids` | `mtlssource.spec` |
| `graphSubscriptionIDs` | `--with.graph-subscription-i-ds` | `--with.graph-subscription-ids` | `mtlssourceentra.spec` |
| `reportVisitedURLsInterval` | `--with.report-visited-ur-ls-interval` | `--with.report-visited-urls-interval` | `webextensionconfig.spec` |